### PR TITLE
fix pytorch syntax error in train_mnist.py

### DIFF
--- a/train_mnist.py
+++ b/train_mnist.py
@@ -82,12 +82,12 @@ def train(net, trainloader, validloader, criterion, optimizer, config,
         # Save model every <save_epochs> epochs
         if epoch % config['train']['save_epochs'] == 0:
             log.info('Saving model...')
-            torch.save(net.basic_net.module.state_dict(),
+            torch.save(net.module.basic_net.state_dict(),
                        model_path + '_epoch%d.pt' % epoch)
     elif config['train']['save_best_only'] and adv_acc > best_acc:
         # Save only the model with the highest adversarial accuracy
         log.info('Saving model...')
-        torch.save(net.basic_net.module.state_dict(), model_path + '.pt')
+        torch.save(net.module.basic_net.state_dict(), model_path + '.pt')
         best_acc = adv_acc
     return best_acc
 


### PR DESCRIPTION
We set up a new environment using the provided `environment.yml` and encounter the following error message while running `train_mnist.py`:

```
Traceback (most recent call last):
  File "train_mnist.py", line 225, in <module>
    main()
  File "train_mnist.py", line 205, in main
    lr_scheduler=None)
  File "train_mnist.py", line 90, in train
    torch.save(net.basic_net.module.state_dict(), model_path + '.pt')
  File "/opt/conda/envs/ENV/lib/python3.7/site-packages/torch/nn/modules/module.py", line 576, i
n __getattr__
    type(self).__name__, name))
AttributeError: 'DataParallel' object has no attribute 'basic_net'
```

Inspection to PyTorch document shows that attribute `module` is directly under object DataParallel. After making the following changes, the training script is able to run, and a file `mnist_at_exp1.pt` under folder `saved_models` is created as a result of running. However, we are unable to empirically verify the correctness of the saved model due to further errors in test script.